### PR TITLE
Added `ReverseArabicChars()` that reverses only Arabic characters

### DIFF
--- a/stringutils.go
+++ b/stringutils.go
@@ -10,6 +10,61 @@ func Reverse(s string) string {
 	return string(r)
 }
 
+// ReverseArabicChars returns a string reversed
+func ReverseArabicChars(s string) string {
+	s = Reverse(s)
+
+	var (
+		arabicChars = getNonArabicCharsRanges(s)
+		runes       = []rune(s)
+	)
+
+	for _, c := range arabicChars {
+		after := runes[c.end+1:]
+		runes = append(runes[0:c.start], []rune(Reverse(string(runes[c.start:c.end+1])))...)
+		runes = append(runes, after...)
+	}
+
+	return string(runes)
+}
+
+type _range struct {
+	start, end int
+}
+
+// getNonArabicCharsRanges returns ranges of the string where non arabic characters exist!
+func getNonArabicCharsRanges(s string) []_range {
+	var (
+		start, end  = 0, 0
+		indexes     = []_range{}
+		foundArabic = false
+	)
+
+	i := 0
+	for _, c := range s {
+		if !isArabicChar(c) {
+			if !foundArabic {
+				start = i
+				foundArabic = true
+			}
+		} else {
+			end = i - 1
+			if end > start {
+				indexes = append(indexes, _range{start, end})
+			}
+			start = i
+			foundArabic = false
+		}
+		i++
+	}
+
+	if len(indexes) == 0 || indexes[len(indexes)-1].end != len(s)-1 {
+		indexes = append(indexes, _range{start, i - 1})
+	}
+
+	return indexes
+}
+
 // SmartLength returns the length of the given string
 // without considering the Arabic Vowels (Tashkeel).
 func SmartLength(s *string) int {
@@ -139,18 +194,22 @@ func getHarf(char rune) Harf {
 	return Harf{Unicode: char, Isolated: char, Medium: char, Final: char}
 }
 
+// isArabicChar checks whether the character is from the arabic alphabet or not
+func isArabicChar(chr rune) bool {
+	for _, c := range alphabet {
+		if c.equals(chr) {
+			return true
+		}
+	}
+	return false
+}
+
 //RemoveAllNonAlphabetChars deletes all characters which are not included in Arabic Alphabet
 func RemoveAllNonArabicChars(text string) string {
 	runes := []rune(text)
 	newText := []rune{}
 	for _, current := range runes {
-		inAlphabet := false
-		for _, s := range alphabet {
-			if s.equals(current) {
-				inAlphabet = true
-			}
-		}
-		if inAlphabet {
+		if isArabicChar(current) {
 			newText = append(newText, current)
 		}
 	}

--- a/stringutils_test.go
+++ b/stringutils_test.go
@@ -107,3 +107,36 @@ func TestRemoveAllNonArabicChars(t *testing.T) {
 		}
 	}
 }
+
+func eqArr(a1, a2 []_range) bool {
+	if len(a1) != len(a2) {
+		return false
+	}
+
+	for i := 0; i < len(a1); i++ {
+		if a1[i].start != a2[i].start && a1[i].end != a2[i].end {
+			return false
+		}
+	}
+
+	return true
+}
+
+func TestGetArabicCharsIndexes(t *testing.T) {
+	cases := []struct {
+		in, want   string
+	}{
+		{"نص عربي", "يبرع صن"},
+		{"السلام عليكم", "مكيلع مالسلا"},
+		{"مرhبا يا friends اصدقاء", "ءاقدصا friends اي ابhرم"},
+		{"Hello World!", "Hello World!"},
+	}
+
+	for _, c := range cases {
+		out := ReverseArabicChars(c.in)
+		if out != c.want {
+			t.Errorf("getArabicCharsRanges(%s) == %s, want %s\n", c.in, out, c.want)
+		}
+	}
+
+}


### PR DESCRIPTION
**Added an another function `ReverseArabicChars()` that reverses only Arabic characters**

** example: **
** The text ** `اذهب الى الحديقة الprivate وال park العمومي `  


is outputted like this ![suppoesed](https://user-images.githubusercontent.com/26228836/141438563-23733d5a-ce5f-44b7-97fd-2d1683bd3aa7.png) using ```ReverseArabicChars(ToGlyph(s))```

and like this ![output](https://user-images.githubusercontent.com/26228836/141438763-a844a0d3-1bcc-4b8c-baa7-d6f3a0fb7c39.png) using ```Reverse(ToGlyph(s))```


the reason it was added as a separate function is because it doesn't execute in a linear time 😅